### PR TITLE
Including the APIWithSwagger.xml in the build output

### DIFF
--- a/ApiWithSwagger/ApiWithSwagger.csproj
+++ b/ApiWithSwagger/ApiWithSwagger.csproj
@@ -19,4 +19,10 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="ApiWithSwagger.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="ApiWithSwagger.xml" />
+  </ItemGroup>
 </Project>

--- a/ApiWithSwagger/ApiWithSwagger.csproj
+++ b/ApiWithSwagger/ApiWithSwagger.csproj
@@ -23,6 +23,8 @@
     <None Remove="ApiWithSwagger.xml" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="ApiWithSwagger.xml" />
+    <Content Include="ApiWithSwagger.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
otherwise there was an error saying this file was missing. The `dotnet publish` command did not include the APIWithSwagger.xml file in the zipped up contents.